### PR TITLE
Fixed SpeedTest_Tracker

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -4174,14 +4174,9 @@
 			"description": "Run a Speedtest every hour and graph the results.",
 			"env": [
 				{
-					"default": "1000",
-					"label": "PUID",
-					"name": "PUID"
-				},
-				{
-					"default": "100",
-					"label": "PGID",
-					"name": "PGID"
+					"default": "arch",
+					"label": "arch",
+					"set": "x86_64"
 				},
 				{
 					"label": "OOKLA_EULA_GDPR",
@@ -4189,7 +4184,7 @@
 					"set": "true"
 				}
 			],
-			"image": "henrywhitaker3/speedtest-tracker:latest-arm",
+			"image": "henrywhitaker3/speedtest-tracker:dev-arm",
 			"logo": "https://raw.githubusercontent.com/novaspirit/pi-hosted/master/pi-hosted_template/images/speedtest-tracker.png",
 			"name": "speedtest-tracker",
 			"platform": "linux",


### PR DESCRIPTION

# Summary
When I tried to deploy SpeedTest Tracker using your template I kept getting an error. The container wasn't able to get time.

# What Changed

I changed henrywhitaker3/speedtest-tracker:dev-arm from henrywhitaker3/speedtest-tracker:latest-arm and removed PUID and PDID and added -e OOKLA_EULA_GDPR : true arch : x86_64.